### PR TITLE
Tanszék logó általános kiterjesztéssel

### DIFF
--- a/include/titlepage.tex
+++ b/include/titlepage.tex
@@ -23,7 +23,7 @@
 \MakeUppercase{\textmd{\gpk}}\\[0.1cm]
 \MakeUppercase{\textmd{\gpktanszek}}\\[0.5cm]
 
-\includegraphics[height=40mm,keepaspectratio]{figures/tanszek_logo.pdf}\\[0.5cm]
+\includegraphics[height=40mm,keepaspectratio]{figures/tanszek_logo}\\[0.5cm]
 \MakeUppercase{\gpkmunkatipusok}
 
 \end{center}

--- a/thesis.tex
+++ b/thesis.tex
@@ -88,8 +88,8 @@
 % \bmemanuf  \bmehds  \bmemogi     \bmemm     \bmept
 \newcommand{\gpktanszek}{\bmemogi}
 
-%TODO Cseréld le a figures/tanszek_logo.pdf fájlt a tanszéked logójára!
-%     [Replace figures/tanszek_logo.pdf with the logo of your department]
+%TODO Cseréld le a figures/tanszek_logo.* fájlt a tanszéked logójára!
+%     [Replace figures/tanszek_logo.* with the logo of your department]
 
 % Elzártan kezelendő dolgozat [Restricted access]
 %TODO Töltsd ki a korlátozás lejártának dátumát! 


### PR DESCRIPTION
A legtöbb tanszéknek nincs .pdf kiterjesztésű logója, kicsit általánosítottam a kódot, hogy más formátumokat is alapból elfogadjon.